### PR TITLE
Enable RustTLS for reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2021"
 chrono = "0.4.19"
 futures = "0.3.21"
 regex = "1.5.5"
-reqwest = "0.11.10"
+reqwest = { version = "0.11.10", features = ["json", "rustls-tls"] }
 serde = "1.0.137"
 serde_json = "1.0.81"
 clap = { version = "3.1.17", features = ["derive"] }


### PR DESCRIPTION
Should minimize the executable size.